### PR TITLE
Fixes to the new PWM  (#1433)

### DIFF
--- a/Sming/SmingCore/HardwarePWM.cpp
+++ b/Sming/SmingCore/HardwarePWM.cpp
@@ -21,6 +21,8 @@
 
 #include "HardwarePWM.h"
 
+#define PERIOD_TO_MAX_DUTY(x) (x * 25)
+
 HardwarePWM::HardwarePWM(uint8* pins, uint8 no_of_pins)
 {
 	channel_count = no_of_pins;
@@ -34,9 +36,10 @@ HardwarePWM::HardwarePWM(uint8* pins, uint8 no_of_pins)
 			pwm_duty_init[i] = 0; // Start with zero output
 			channels[i] = pins[i];
 		}
-		pwm_init(1000, pwm_duty_init, no_of_pins, io_info);
+		const int initial_period = 1000;
+		pwm_init(initial_period, pwm_duty_init, no_of_pins, io_info);
 		pwm_start();
-		maxduty = 22222; // for period of 1000
+		maxduty = PERIOD_TO_MAX_DUTY(initial_period); // for period of 1000
 	}
 }
 
@@ -129,7 +132,7 @@ uint32 HardwarePWM::getPeriod()
  */
 void HardwarePWM::setPeriod(uint32 period)
 {
-	maxduty = (period * 1000) / 45;
+	maxduty = PERIOD_TO_MAX_DUTY(period);
 	pwm_set_period(period);
 	pwm_start();
 }

--- a/Sming/third-party/.patches/pwm.patch
+++ b/Sming/third-party/.patches/pwm.patch
@@ -1,16 +1,31 @@
 diff --git a/pwm.c b/pwm.c
-index 6df21ac..d039908 100644
+index 6df21ac..b79002c 100644
 --- a/pwm.c
 +++ b/pwm.c
 @@ -16,6 +16,8 @@
   * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
   */
  
-+#include <user_config.h> 
++#include <user_config.h>
 +
  /* Set the following three defines to your needs */
  
  #ifndef SDK_PWM_PERIOD_COMPAT_MODE
+@@ -31,10 +33,10 @@
+ 
+ #define PWM_MAX_TICKS 0x7fffff
+ #if SDK_PWM_PERIOD_COMPAT_MODE
+-#define PWM_PERIOD_TO_TICKS(x) (x * 0.2)
+-#define PWM_DUTY_TO_TICKS(x) (x * 5)
+-#define PWM_MAX_DUTY (PWM_MAX_TICKS * 0.2)
+-#define PWM_MAX_PERIOD (PWM_MAX_TICKS * 5)
++#define PWM_PERIOD_TO_TICKS(x) (x * 5)
++#define PWM_DUTY_TO_TICKS(x) (x * 0.2)
++#define PWM_MAX_DUTY (PWM_MAX_TICKS * 5)
++#define PWM_MAX_PERIOD (PWM_MAX_TICKS * 0.2)
+ #else
+ #define PWM_PERIOD_TO_TICKS(x) (x)
+ #define PWM_DUTY_TO_TICKS(x) (x)
 @@ -109,8 +111,8 @@ struct timer_regs {
  };
  static struct timer_regs* timer = (struct timer_regs*)(0x60000600);

--- a/samples/Basic_HwPWM/Makefile-user.mk
+++ b/samples/Basic_HwPWM/Makefile-user.mk
@@ -37,5 +37,5 @@
 DISABLE_SPIFFS = 1
 # SPIFF_FILES = files
 
-# Comment the line below if you want to Espressif's PWM library. 
-ENABLE_CUSTOM_PWM=1
+# Uncomment the line below if you want to Espressif's PWM library.
+#ENABLE_CUSTOM_PWM=0

--- a/samples/Basic_HwPWM/app/application.cpp
+++ b/samples/Basic_HwPWM/app/application.cpp
@@ -24,14 +24,17 @@ HardwarePWM HW_pwm(pins, 8);
 
 Timer procTimer;
 int32 i = 0;
-int32 inc = 100;
 bool countUp = true;
+
+int maxDuty = HW_pwm.getMaxDuty();
+int32 inc = maxDuty / 50;
+
 void doPWM()
 {
 	if(countUp == true) {
 		i += inc;
-		if(i >= 22222) {
-			i = 22222;
+		if(i >= maxDuty) {
+			i = maxDuty;
 			countUp = false;
 		}
 	} else {
@@ -54,14 +57,14 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Setting PWM values on 8 different pins
-	HW_pwm.analogWrite(4, 22222);
-	HW_pwm.analogWrite(5, 11111);
-	HW_pwm.analogWrite(0, 22222);
-	HW_pwm.analogWrite(2, 11111);
-	HW_pwm.analogWrite(15, 22222);
-	HW_pwm.analogWrite(13, 11111);
-	HW_pwm.analogWrite(12, 22222);
-	HW_pwm.analogWrite(14, 11111);
+	HW_pwm.analogWrite(4, maxDuty);
+	HW_pwm.analogWrite(5, maxDuty / 2);
+	HW_pwm.analogWrite(0, maxDuty);
+	HW_pwm.analogWrite(2, maxDuty / 2);
+	HW_pwm.analogWrite(15, 0);
+	HW_pwm.analogWrite(13, maxDuty / 3);
+	HW_pwm.analogWrite(12, 2 * maxDuty / 3);
+	HW_pwm.analogWrite(14, maxDuty);
 
 	debugf("PWM output set on all 8 Pins. Kindly check...");
 	debugf("Now Pin 2 will go from 0 to VCC to 0 in cycles.");


### PR DESCRIPTION
* Fix duty and period conversion in pwm.c
Conversions in pwm.c are bugous. Fix is already available for the
original repository, but the merge request has not yet been accepted.
See https://github.com/StefanBruens/ESP8266_new_pwm/pull/26/
for details.

* Create macro to calculate max duty

* Remove hard-coded maximum duty

Class HardwarePWM actually provides a function to query the maximum
value of duty.

* Fix comment

ENABLE_CUSTOM_PWM defaults to 1 since d870c27.