### PR TITLE
Rewrite base64 support using libb64 routines. Improvements to String …

### DIFF
--- a/Sming/Services/WebHelpers/base64.cpp
+++ b/Sming/Services/WebHelpers/base64.cpp
@@ -1,115 +1,75 @@
-/* base64.c : base-64 / MIME encode/decode */
-/* PUBLIC DOMAIN - Jon Mayo - November 13, 2003 */
-/* $Id: base64.c 156 2007-07-12 23:29:10Z orange $ */
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ *
+ * @author: 2018 - Mikee47 <mike@sillyhouse.net>
+ *
+ ****/
+
 #include "base64.h"
 
-#include <c_types.h>
-#include <ctype.h>
+#include "../libb64/cencode.h"
+#include "../libb64/cdecode.h"
 
+// Base-64 encoding produces 3 output bytes for every 2 input bytes
+#define MIN_ENCODE_LEN(_in_len) (((_in_len)*3 + 1) / 2)
+#define MIN_DECODE_LEN(_in_len) (((_in_len)*2 + 2) / 3)
 
-static const uint8_t base64enc_tab[]= "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-static const uint8_t base64dec_tab[256]= {
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255, 62,255,255,255, 63,
-	 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,255,255,255,  0,255,255,
-	255,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-	 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,255,255,255,255,255,
-	255, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-	 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-};
-
-void base64encode(const unsigned char in[3], unsigned char out[4], int count)
+int base64_encode(size_t in_len, const unsigned char* in, size_t out_len, char* out)
 {
-	out[0]=base64enc_tab[(in[0]>>2)];
-	out[1]=base64enc_tab[((in[0]&3)<<4)|(in[1]>>4)];
-	out[2]=count<2 ? '=' : base64enc_tab[((in[1]&15)<<2)|(in[2]>>6)];
-	out[3]=count<3 ? '=' : base64enc_tab[(in[2]&63)];
+	// Base-64 encoding produces 3 output bytes for every 2 input bytes
+	unsigned min_out_len = MIN_ENCODE_LEN(in_len);
+	if (out_len < min_out_len)
+		return -1;
+
+	base64_encodestate state;
+	base64_init_encodestate(&state, 0); // Don't include any linebreaks
+	int codelength = base64_encode_block((const char*)in, in_len, out, &state);
+	codelength += base64_encode_blockend(out + codelength, &state);
+	return codelength;
 }
 
-#ifndef ENABLE_SSL
-int base64decode(const char in[4], char out[3])
+String base64_encode(const unsigned char* in, size_t in_len)
 {
-	uint8_t v[4];
+	String s;
+	if (!s.setLength(MIN_ENCODE_LEN(in_len)))
+		return nullptr;
 
-	v[0]=base64dec_tab[(unsigned)in[0]];
-	v[1]=base64dec_tab[(unsigned)in[1]];
-	v[2]=base64dec_tab[(unsigned)in[2]];
-	v[3]=base64dec_tab[(unsigned)in[3]];
+	int len = base64_encode(in_len, in, s.length(), s.begin());
+	if (len < 0)
+		return nullptr;
 
-	out[0]=(v[0]<<2)|(v[1]>>4); 
-	out[1]=(v[1]<<4)|(v[2]>>2); 
-	out[2]=(v[2]<<6)|(v[3]); 
-	return (v[0]|v[1]|v[2]|v[3])!=255 ? in[3]=='=' ? in[2]=='=' ? 1 : 2 : 3 : 0;
+	s.setLength(len);
+	return s;
 }
 
 /* decode a base64 string in one shot */
-int base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out) {
-	unsigned ii, io;
-	uint_least32_t v;
-	unsigned rem;
+int base64_decode(size_t in_len, const char* in, size_t out_len, unsigned char* out)
+{
+	if (out_len < MIN_DECODE_LEN(in_len))
+		return -1;
 
-	for(io=0,ii=0,v=0,rem=0;ii<in_len;ii++) {
-		unsigned char ch;
-		if(isspace(in[ii])) continue;
-		if(in[ii]=='=') break; /* stop at = */
-		ch=base64dec_tab[(unsigned)in[ii]];
-		if(ch==255) break; /* stop at a parse error */
-		v=(v<<6)|ch;
-		rem+=6;
-		if(rem>=8) {
-			rem-=8;
-			if(io>=out_len) return -1; /* truncation is failure */
-			out[io++]=(v>>rem)&255;
-		}
-	}
-	if(rem>=8) {
-		rem-=8;
-		if(io>=out_len) return -1; /* truncation is failure */
-		out[io++]=(v>>rem)&255;
-	}
-	return io;
-}
-#endif
-
-int base64_encode(size_t in_len, const unsigned char *in, size_t out_len, char *out) {
-	unsigned ii, io;
-	uint_least32_t v;
-	unsigned rem;
-
-	for(io=0,ii=0,v=0,rem=0;ii<in_len;ii++) {
-		unsigned char ch;
-		ch=in[ii];
-		v=(v<<8)|ch;
-		rem+=8;
-		while(rem>=6) {
-			rem-=6;
-			if(io>=out_len) return -1; /* truncation is failure */
-			out[io++]=base64enc_tab[(v>>rem)&63];
-		}
-	}
-	if(rem) {
-		v<<=(6-rem);
-		if(io>=out_len) return -1; /* truncation is failure */
-		out[io++]=base64enc_tab[v&63];
-	}
-	while(io&3) {
-		if(io>=out_len) return -1; /* truncation is failure */
-		out[io++]='=';
-	}
-	if(io>=out_len) return -1; /* no room for null terminator */
-	out[io]=0;
-	return io;
+	base64_decodestate _state;
+	base64_init_decodestate(&_state);
+	return base64_decode_block(in, in_len, (char*)out, &_state);
 }
 
-/* vim: ts=4 sts=0 noet sw=4
-*/
+
+String base64_decode(const char *in, size_t in_len)
+{
+	String s;
+	if (!s.setLength(MIN_DECODE_LEN(in_len)))
+		return nullptr;
+
+	int outlen = base64_decode(in_len, in, s.length(), (unsigned char*)s.begin());
+	if (outlen < 0)
+		return nullptr;
+
+	s.setLength(outlen);
+	return s;
+}
+
+

--- a/Sming/Services/WebHelpers/base64.h
+++ b/Sming/Services/WebHelpers/base64.h
@@ -1,31 +1,74 @@
-/* base64.h : base-64 / MIME encode/decode */
-/* PUBLIC DOMAIN - Jon Mayo - November 13, 2003 */
-/* $Id: base64.h 128 2007-04-20 08:20:40Z orange $ */
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ *
+ * @author: 2018 - Mikee47 <mike@sillyhouse.net>
+ *
+ * 	Functions added to work with String objects for ease of use.
+ *
+ ****/
+
 #ifndef BASE64_H
 #define BASE64_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "WString.h"
 
-#include <user_config.h>
-
-/* used to encode 3 bytes into 4 base64 digits */
-void base64encode(const unsigned char in[3], unsigned char out[4], int count);
-
-/* used to decode 4 base64 digits into 3 bytes */
-int base64decode(const char in[4], char out[3]);
-
-/* encode binary data into base64 digits with MIME style === pads */
+/** @brief encode binary data into base64 digits with MIME style === pads
+ *  @param in_len quantity of characters to encode
+ *  @param in data to encode
+ *  @param out_len size of output buffer
+ *  @param out buffer for base64-encoded text
+ *  @retval int length of encoded text, or -1 if output buffer is too small
+ *  @note Output is broken by newline every 72 characters. Final terminating newline
+ *  is not included.
+ */
 int base64_encode(size_t in_len, const unsigned char *in, size_t out_len, char *out);
 
-#ifndef ENABLE_SSL
-/* decode base64 digits with MIME style === pads into binary data */
-int base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out);
-#endif
+/** @brief encode a block of data into base64, stored in a String
+ *  @param in text to encode
+ *  @param in_len quantity of characters to encode
+ *  @retval String the base64-encoded text
+ */
+String base64_encode(const unsigned char *in, size_t in_len);
 
-#ifdef __cplusplus
+/** @brief encode a block of data into base64, both input and output are String objects
+ *  @param in
+ *  @retval String
+ */
+static inline String base64_encode(const String& in)
+{
+	return base64_encode((unsigned char*)in.c_str(), in.length());
 }
-#endif
+
+
+/** @brief decode base64 digits with MIME style === pads into binary data
+ *  @param in_len length of source base64 text in characters
+ *  @param in base64-encoded text
+ *  @param out_len size of output buffer
+ *  @param out buffer for decoded output
+ *  @retval int length of decoded output, or -1 if output buffer is too small
+ */
+int base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out);
+
+/** @brief decode base64 text into binary data
+ *  @param in source base64-encoded text
+ *  @param in_len length of input text in characters
+ *  @retval String the decoded text
+ */
+String base64_decode(const char *in, size_t in_len);
+
+/** @brief encode a block of data into base64, both input and output are String objects
+ *  @param in
+ *  @retval String
+ */
+static inline String base64_decode(const String& in)
+{
+	return base64_decode(in.c_str(), in.length());
+}
+
+
 
 #endif /* BASE64_H */

--- a/Sming/Services/libb64/cdecode.c
+++ b/Sming/Services/libb64/cdecode.c
@@ -1,0 +1,88 @@
+/*
+cdecoder.c - c source to a base64 decoding algorithm implementation
+
+This is part of the libb64 project, and has been placed in the public domain.
+For details, see http://sourceforge.net/projects/libb64
+*/
+
+#include "cdecode.h"
+
+int base64_decode_value(char value_in)
+{
+	static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
+	static const char decoding_size = sizeof(decoding);
+	value_in -= 43;
+	if (value_in < 0 || value_in >= decoding_size) return -1;
+	return decoding[(int)value_in];
+}
+
+void base64_init_decodestate(base64_decodestate* state_in)
+{
+	state_in->step = step_a;
+	state_in->plainchar = 0;
+}
+
+unsigned base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in)
+{
+	const char* codechar = code_in;
+	char* plainchar = plaintext_out;
+	char fragment;
+
+	*plainchar = state_in->plainchar;
+
+	switch (state_in->step)
+	{
+		while (1)
+		{
+	case step_a:
+			do {
+				if (codechar == code_in+length_in)
+				{
+					state_in->step = step_a;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while (fragment < 0);
+			*plainchar    = (fragment & 0x03f) << 2;
+	case step_b:
+			do {
+				if (codechar == code_in+length_in)
+				{
+					state_in->step = step_b;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while (fragment < 0);
+			*plainchar++ |= (fragment & 0x030) >> 4;
+			*plainchar    = (fragment & 0x00f) << 4;
+	case step_c:
+			do {
+				if (codechar == code_in+length_in)
+				{
+					state_in->step = step_c;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while (fragment < 0);
+			*plainchar++ |= (fragment & 0x03c) >> 2;
+			*plainchar    = (fragment & 0x003) << 6;
+	case step_d:
+			do {
+				if (codechar == code_in+length_in)
+				{
+					state_in->step = step_d;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while (fragment < 0);
+			*plainchar++   |= (fragment & 0x03f);
+		}
+	}
+	/* control should not reach here */
+	return plainchar - plaintext_out;
+}
+

--- a/Sming/Services/libb64/cdecode.h
+++ b/Sming/Services/libb64/cdecode.h
@@ -1,0 +1,44 @@
+/*
+cdecode.h - c header for a base64 decoding algorithm
+
+This is part of the libb64 project, and has been placed in the public domain.
+For details, see http://sourceforge.net/projects/libb64
+*/
+
+#ifndef BASE64_CDECODE_H
+#define BASE64_CDECODE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum
+{
+	step_a, step_b, step_c, step_d
+} base64_decodestep;
+
+typedef struct
+{
+	base64_decodestep step;
+	char plainchar;
+} base64_decodestate;
+
+/** @brief Call first to initialise decoder
+ *  @param state_in
+ */
+void base64_init_decodestate(base64_decodestate* state_in);
+
+/** @brief Call as many times as required to decode text
+ *  @param code_in
+ *  @param length_in
+ *  @param plaintext_out may use same buffer as code_in if required
+ *  @param state_in
+ *  @retval unsigned number of bytes output
+ */
+unsigned base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BASE64_CDECODE_H */

--- a/Sming/Services/libb64/cencode.c
+++ b/Sming/Services/libb64/cencode.c
@@ -3,17 +3,21 @@ cencoder.c - c source to a base64 encoding algorithm implementation
 
 This is part of the libb64 project, and has been placed in the public domain.
 For details, see http://sourceforge.net/projects/libb64
+
+@author mikee47 <mike@sillyhouse.net>
+
+The trailing newline is not added, so any encodings producing less than 72 characters output
+are returned in a single line of text. Anything longer is still wrapped.
 */
 
 #include "cencode.h"
 
-const int CHARS_PER_LINE = 72;
-
-void base64_init_encodestate(base64_encodestate* state_in)
+void base64_init_encodestate(base64_encodestate* state_in, unsigned chars_per_line)
 {
 	state_in->step = step_A;
 	state_in->result = 0;
 	state_in->stepcount = 0;
+	state_in->steps_per_line = chars_per_line / 4;
 }
 
 char base64_encode_value(char value_in)
@@ -23,7 +27,7 @@ char base64_encode_value(char value_in)
 	return encoding[(int)value_in];
 }
 
-int base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in)
+unsigned base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in)
 {
 	const char* plainchar = plaintext_in;
 	const char* const plaintextend = plaintext_in + length_in;
@@ -73,7 +77,7 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 			*codechar++ = base64_encode_value(result);
 
 			++(state_in->stepcount);
-			if (state_in->stepcount == CHARS_PER_LINE/4)
+			if (state_in->stepcount == state_in->steps_per_line)
 			{
 				*codechar++ = '\n';
 				state_in->stepcount = 0;
@@ -84,7 +88,7 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 	return codechar - code_out;
 }
 
-int base64_encode_blockend(char* code_out, base64_encodestate* state_in)
+unsigned base64_encode_blockend(char* code_out, base64_encodestate* state_in)
 {
 	char* codechar = code_out;
 
@@ -102,7 +106,7 @@ int base64_encode_blockend(char* code_out, base64_encodestate* state_in)
 	case step_A:
 		break;
 	}
-	*codechar++ = '\n';
 
 	return codechar - code_out;
 }
+

--- a/Sming/Services/libb64/cencode.h
+++ b/Sming/Services/libb64/cencode.h
@@ -22,15 +22,29 @@ typedef struct
 	base64_encodestep step;
 	char result;
 	int stepcount;
+	unsigned steps_per_line; ///< Non-zero to limit encoded line lengths
 } base64_encodestate;
 
-void base64_init_encodestate(base64_encodestate* state_in);
+/** @brief Call first to initialise encoder
+ *  @param state_in
+ *  @param charsPerLine linebreaks added as required. Specify 0 to disable line breaking.
+ */
+void base64_init_encodestate(base64_encodestate* state_in, unsigned chars_per_line);
 
-char base64_encode_value(char value_in);
+/** @brief Call as many times as required to encode text
+ *  @param plaintext_in
+ *  @param length_in
+ *  @param code_out buffer must be at least (4 * length_in / 3) bytes
+ *  @param state_in
+ *  @retval unsigned number of bytes output
+ */
+unsigned base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in);
 
-int base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in);
-
-int base64_encode_blockend(char* code_out, base64_encodestate* state_in);
+/** @brief Call to finish encoding and return any remaining output bytes (maximum 2).
+ *  @note This function does NOT append any extraneous characters (such as a carriage return) to the
+ *  output text.
+ */
+unsigned base64_encode_blockend(char* code_out, base64_encodestate* state_in);
 
 #ifdef __cplusplus
 }

--- a/Sming/SmingCore/Data/Stream/Base64OutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/Base64OutputStream.cpp
@@ -10,11 +10,14 @@
 
 #include "Base64OutputStream.h"
 
+// Produce line breaks in output encodings
+const unsigned CHARS_PER_LINE = 72;
+
 Base64OutputStream::Base64OutputStream(ReadWriteStream* stream, size_t resultSize /* = 512 */)
 	: StreamTransformer(stream, nullptr, resultSize, (resultSize / 4))
 
 {
-	base64_init_encodestate(&state);
+	base64_init_encodestate(&state, CHARS_PER_LINE);
 
 	transformCallback = std::bind(&Base64OutputStream::encode, this, std::placeholders::_1, std::placeholders::_2,
 								  std::placeholders::_3, std::placeholders::_4);
@@ -25,7 +28,6 @@ int Base64OutputStream::encode(uint8_t* source, size_t sourceLength, uint8_t* ta
 	int count = 0;
 	if(sourceLength == 0) {
 		count = base64_encode_blockend((char*)target, &state);
-		count--; // the last byte is a newline. we don't need it.
 	} else {
 		count = base64_encode_block((const char*)source, sourceLength, (char*)target, &state);
 	}

--- a/Sming/SmingCore/Data/Structures.h
+++ b/Sming/SmingCore/Data/Structures.h
@@ -14,9 +14,6 @@
 #include "../../Wiring/FILO.h"
 #include "../../Wiring/WString.h"
 #include "../../Wiring/WHashMap.h"
-extern "C" {
-int strcasecmp(const char*, const char*);
-}
 
 /**
  * WARNING: For the moment the name "SimpleConcurrentQueue" is very misleading.

--- a/Sming/SmingCore/Network/Http/HttpRequestAuth.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequestAuth.cpp
@@ -23,12 +23,7 @@ HttpBasicAuth::HttpBasicAuth(const String& username, const String& password)
 // Basic Auth
 void HttpBasicAuth::setRequest(HttpRequest* request)
 {
-	String clearText = username + ":" + password;
-	int hashLength = clearText.length() * 4;
-	char hash[hashLength];
-	base64_encode(clearText.length(), (const unsigned char*)clearText.c_str(), hashLength, hash);
-
-	request->setHeader("Authorization", "Basic " + String(hash));
+	request->setHeader("Authorization", "Basic " + base64_encode(username + ":" + password));
 }
 
 // Digest Auth

--- a/Sming/SmingCore/Network/Http/Websocket/WebSocketConnection.cpp
+++ b/Sming/SmingCore/Network/Http/Websocket/WebSocketConnection.cpp
@@ -31,17 +31,15 @@ bool WebSocketConnection::initialize(HttpRequest& request, HttpResponse& respons
 		return false;
 
 	state = eWSCS_Open;
-	String hash = request.getHeader("Sec-WebSocket-Key");
-	hash.trim();
-	hash = hash + secret;
-	unsigned char data[SHA1_SIZE];
-	char secure[SHA1_SIZE * 4];
-	sha1(data, hash.c_str(), hash.length());
-	base64_encode(SHA1_SIZE, data, SHA1_SIZE * 4, secure);
+	String token = request.getHeader("Sec-WebSocket-Key");
+	token.trim();
+	token = token + secret;
+	unsigned char hash[SHA1_SIZE];
+	sha1(hash, token.c_str(), token.length());
 	response.code = HTTP_STATUS_SWITCHING_PROTOCOLS;
 	response.setHeader("Connection", "Upgrade");
 	response.setHeader("Upgrade", "websocket");
-	response.setHeader("Sec-WebSocket-Accept", secure);
+	response.setHeader("Sec-WebSocket-Accept", base64_encode(hash, SHA1_SIZE));
 
 	delete stream;
 	stream = new EndlessMemoryStream();

--- a/Sming/SmingCore/Network/WebsocketClient.cpp
+++ b/Sming/SmingCore/Network/WebsocketClient.cpp
@@ -42,18 +42,14 @@ bool WebsocketClient::connect(String url, uint32_t sslOptions /* = 0 */)
 	}
 	TcpClient::connect(_uri.Host, _uri.Port, useSsl, sslOptions);
 	debug_d("Connecting to Server");
-	unsigned char keyStart[17];
-	char b64Key[25];
-	memset(b64Key, 0, sizeof(b64Key));
+
 	_mode = wsMode::Connecting; // Server Connected / WS Upgrade request sent
 
-	for(int i = 0; i < 16; ++i) {
+	uint8_t keyStart[16];
+	for(unsigned i = 0; i < sizeof(keyStart); ++i) {
 		keyStart[i] = 1 + os_random() % 255;
 	}
-
-	base64_encode(16, (const unsigned char*)keyStart, 24, (char*)b64Key);
-
-	_key.setString(b64Key, 24);
+	_key = base64_encode(keyStart, sizeof(keyStart));
 
 	String protocol = "chat";
 	sendString("GET ");
@@ -93,8 +89,6 @@ bool WebsocketClient::_verifyKey(char* buf, int size)
 {
 	const char* serverHashedKey = strstri(buf, "sec-websocket-accept: ");
 	char* endKey = NULL;
-	unsigned char hashedKey[20];
-	char base64HashedKey[20 * 4];
 	String keyToHash = _key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 	if(!serverHashedKey) {
@@ -112,11 +106,11 @@ bool WebsocketClient::_verifyKey(char* buf, int size)
 
 	*endKey = 0;
 
-	sha1(hashedKey, keyToHash.c_str(), keyToHash.length());
-	base64_encode(sizeof(hashedKey), hashedKey, sizeof(base64HashedKey), base64HashedKey);
-
-	if(strstr(serverHashedKey, base64HashedKey) != serverHashedKey) {
-		debug_e("wscli key mismatch: %s | %s", serverHashedKey, base64HashedKey);
+	unsigned char hash[SHA1_SIZE];
+	sha1(hash, keyToHash.c_str(), keyToHash.length());
+	String base64hash = base64_encode(hash, sizeof(hash));
+	if(base64hash != serverHashedKey) {
+		debug_e("wscli key mismatch: %s | %s", serverHashedKey, base64hash.c_str());
 		return false;
 	}
 

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -77,7 +77,15 @@ class String
     // is left unchanged).  reserve(0), if successful, will validate an
     // invalid string (i.e., "if (s)" will be true afterwards)
     unsigned char reserve(unsigned int size);
-    inline unsigned int length(void) const
+
+	/** @brief set the string length accordingly, expanding if necessary
+	 *  @param length required for string (nul terminator additional)
+	 *  @retval true on success, false on failure
+	 *  @note extra characters are undefined
+	 */
+	bool setLength(unsigned int length);
+
+	inline unsigned int length(void) const
     {
       return len;
     }
@@ -200,7 +208,8 @@ class String
     unsigned char operator > (const String &rhs) const;
     unsigned char operator <= (const String &rhs) const;
     unsigned char operator >= (const String &rhs) const;
-    unsigned char equalsIgnoreCase(const String &s) const;
+    unsigned char equalsIgnoreCase(const char* cstr) const;
+    unsigned char equalsIgnoreCase(const String &s2) const;
     unsigned char startsWith(const String &prefix) const;
     unsigned char startsWith(const String &prefix, unsigned int offset) const;
     unsigned char endsWith(const String &suffix) const;

--- a/Sming/system/include/stringutil.h
+++ b/Sming/system/include/stringutil.h
@@ -14,12 +14,25 @@
 extern "C" {
 #endif
 
-  /** Return pointer to occurence of substring in string. Case insensitive.
+#include "c_types.h"
+
+/** Return pointer to occurence of substring in string. Case insensitive.
    * \param[in] pString string to work with
    * \param[in] pToken string to locate
    * \return pointer to first occurence in of pToken in pString or NULL if not found
    */
 const char* strstri(const char* pString, const char* pToken);
+
+/** @brief A case-insensitive @code{strcmp}.
+	@note non-ANSI GNU C library extension
+*/
+int strcasecmp(const char* s1, const char* s2);
+
+/** @brief Returns a pointer to the first occurrence of @var{needle} (length @var{needle_len}) in @var{haystack} (length @var{haystack_len}).
+	@retval void* @code{NULL} if not found.
+	@note non-ANSI GNU C library extension
+*/
+void* memmem(const void* haystack, size_t haystacklen, const void* needle, size_t needlelen);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
…class and adding support for non-ASCII data. (#1437)

Add additional functions to encode/decode using Strings
Add String::setLength to allow direct buffer resizing and avoid double-copy operations
Make String objects useable with non-ASCII data by replacing strcpy/memcpy calls with memmove. An example of this is null-separated text segments.